### PR TITLE
Integrate region detection with WorldGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Attributioner is a Paper plugin that manages player attributes. It applies attri
 - `/attributioner regions` lists all regions and their configured attributes for quick debugging.
 - `/attributioner debug` toggles debug logging on or off.
 - `/attributioner info <player>` shows all custom attribute modifiers applied to the given player.
+- Automatically monitors online players every second to detect WorldGuard region changes.
 
 ## Building
 
@@ -42,7 +43,7 @@ Each key under `regions` corresponds to a WorldGuard region by ID. When a player
 
 ## Usage
 
-1. Install WorldGuard and RegionEvents on your Paper server.
+1. Install WorldGuard on your Paper server.
 2. Place the built Attributioner JAR in the `plugins` directory and start the server.
 3. Edit the generated `config.yml` to define your regions and attribute modifiers.
 4. Use `/attributioner reload` to reload the configuration without restarting the server.

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     compileOnly("com.sk89q.worldedit:worldedit-bukkit:7.3.14")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.14")
 
-    // Add RegionEvents API for worldguard enter/exit region events
-    compileOnly("com.github.aivruu:region-events:1.1.2")
 }
 
 tasks {

--- a/src/main/java/au/com/addstar/attributioner/Attributioner.java
+++ b/src/main/java/au/com/addstar/attributioner/Attributioner.java
@@ -15,9 +15,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.*;
 import java.util.logging.Level;
 
+// WorldGuard region polling
+import au.com.addstar.attributioner.RegionListener;
+
 public class Attributioner extends JavaPlugin implements Listener {
     private final Map<String, Map<Attribute, AttributeModifier>> regionModifiers = new HashMap<>();
     private boolean debugMode = false;
+    private RegionListener regionListener;
 
     @Override
     public void onEnable() {
@@ -27,11 +31,17 @@ public class Attributioner extends JavaPlugin implements Listener {
         AttributeManager manager = new AttributeManager(this);
         getServer().getPluginManager().registerEvents(this, this);
         getCommand("attributioner").setExecutor(new AttributionerCommand(this, manager));
-        if (getServer().getPluginManager().isPluginEnabled("RegionEvents")) {
-            getLogger().info("RegionEvents plugin found, registering region listener.");
-            getServer().getPluginManager().registerEvents(new RegionListener(this, manager), this);
-        } else {
-            getLogger().warning("RegionEvents plugin not loaded, region-based attribute modifiers will not work.");
+
+        RegionListener listener = new RegionListener(this, manager, 20L);
+        getServer().getPluginManager().registerEvents(listener, this);
+        listener.start();
+        this.regionListener = listener;
+    }
+
+    @Override
+    public void onDisable() {
+        if (regionListener != null) {
+            regionListener.stop();
         }
     }
 

--- a/src/main/java/au/com/addstar/attributioner/AttributionerCommand.java
+++ b/src/main/java/au/com/addstar/attributioner/AttributionerCommand.java
@@ -1,7 +1,5 @@
 package au.com.addstar.attributioner;
 
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import io.github.aivruu.regionevents.util.RegionHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -13,8 +11,6 @@ import org.bukkit.attribute.AttributeModifier;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
 
 public class AttributionerCommand implements CommandExecutor {
     private final Attributioner plugin;

--- a/src/main/java/au/com/addstar/attributioner/RegionListener.java
+++ b/src/main/java/au/com/addstar/attributioner/RegionListener.java
@@ -1,11 +1,11 @@
 package au.com.addstar.attributioner;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.managers.RegionContainer;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -25,6 +25,7 @@ public class RegionListener implements Listener, Runnable {
     private final AttributeManager manager;
     private final Map<UUID, Set<String>> playerRegions = new HashMap<>();
     private final long interval;
+    private final RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
     private BukkitTask task;
 
     public RegionListener(Attributioner plugin, AttributeManager manager, long intervalTicks) {
@@ -88,7 +89,6 @@ public class RegionListener implements Listener, Runnable {
     }
 
     private Set<String> getRegions(Player player) {
-        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionManager manager = container.get(BukkitAdapter.adapt(player.getWorld()));
         if (manager == null) {
             return Collections.emptySet();

--- a/src/main/java/au/com/addstar/attributioner/RegionListener.java
+++ b/src/main/java/au/com/addstar/attributioner/RegionListener.java
@@ -1,60 +1,103 @@
 package au.com.addstar.attributioner;
 
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.managers.RegionContainer;
+import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import io.github.aivruu.regionevents.event.RegionEnteredEvent;
-import io.github.aivruu.regionevents.event.RegionQuitEvent;
-import io.github.aivruu.regionevents.util.RegionHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitTask;
 
-import java.util.logging.Level;
+import java.util.*;
 
-import java.util.Set;
-
-public class RegionListener implements Listener {
+/**
+ * Periodically checks the regions each player is in and triggers
+ * attribute application or removal when regions change.
+ */
+public class RegionListener implements Listener, Runnable {
     private final Attributioner plugin;
     private final AttributeManager manager;
+    private final Map<UUID, Set<String>> playerRegions = new HashMap<>();
+    private final long interval;
+    private BukkitTask task;
 
-    public RegionListener(Attributioner plugin, AttributeManager manager) {
+    public RegionListener(Attributioner plugin, AttributeManager manager, long intervalTicks) {
         this.plugin = plugin;
         this.manager = manager;
+        this.interval = intervalTicks;
+    }
+
+    /** Start polling online players */
+    public void start() {
+        task = Bukkit.getScheduler().runTaskTimer(plugin, this, 20L, interval);
+    }
+
+    /** Stop the polling task */
+    public void stop() {
+        if (task != null) {
+            task.cancel();
+        }
+    }
+
+    @Override
+    public void run() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            updatePlayer(player);
+        }
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-            Set<ProtectedRegion> regions = RegionHelper.searchAtLocation(player.getWorld(), player.getLocation());
-            for (ProtectedRegion region : regions) {
-                String id = region.getId();
-                if (plugin.getRegionModifiers().containsKey(id)) {
-                    manager.applyModifiers(player, id);
-                }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> updatePlayer(event.getPlayer()), 20L);
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        playerRegions.remove(event.getPlayer().getUniqueId());
+    }
+
+    private void updatePlayer(Player player) {
+        Set<String> current = getRegions(player);
+        Set<String> previous = playerRegions.getOrDefault(player.getUniqueId(), Collections.emptySet());
+
+        // Entered regions
+        for (String id : current) {
+            if (!previous.contains(id) && plugin.getRegionModifiers().containsKey(id)) {
+                plugin.debugMsg(String.format("%s entered region %s, applying %s", player.getName(), id,
+                        plugin.getRegionModifiers().get(id).keySet()));
+                manager.applyModifiers(player, id);
             }
-        }, 20L);
-    }
-
-    @EventHandler
-    public void onRegionEnter(RegionEnteredEvent event) {
-        String id = event.region().getId();
-        if (plugin.getRegionModifiers().containsKey(id)) {
-            plugin.debugMsg(String.format("%s entered region %s, applying %s",
-                    new Object[]{event.player().getName(), id, plugin.getRegionModifiers().get(id).keySet()}));
-            manager.applyModifiers(event.player(), id);
         }
-    }
 
-    @EventHandler
-    public void onRegionLeave(RegionQuitEvent event) {
-        String id = event.region().getId();
-        if (plugin.getRegionModifiers().containsKey(id)) {
-            plugin.debugMsg(String.format("%s left region %s, removing %s",
-                    new Object[]{event.player().getName(), id, plugin.getRegionModifiers().get(id).keySet()}));
-            manager.removeModifiers(event.player(), id);
+        // Left regions
+        for (String id : previous) {
+            if (!current.contains(id) && plugin.getRegionModifiers().containsKey(id)) {
+                plugin.debugMsg(String.format("%s left region %s, removing %s", player.getName(), id,
+                        plugin.getRegionModifiers().get(id).keySet()));
+                manager.removeModifiers(player, id);
+            }
         }
+
+        playerRegions.put(player.getUniqueId(), current);
     }
 
+    private Set<String> getRegions(Player player) {
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionManager manager = container.get(BukkitAdapter.adapt(player.getWorld()));
+        if (manager == null) {
+            return Collections.emptySet();
+        }
+        ApplicableRegionSet set = manager.getApplicableRegions(BukkitAdapter.asBlockVector(player.getLocation()));
+        Set<String> ids = new HashSet<>();
+        for (ProtectedRegion region : set) {
+            ids.add(region.getId());
+        }
+        return ids;
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: Attributioner
 main: au.com.addstar.attributioner.Attributioner
 version: 1.0
 api-version: '1.21'
-softdepend: [WorldGuard, RegionEvents]
+softdepend: [WorldGuard]
 commands:
   attributioner:
     description: Admin commands for Attributioner


### PR DESCRIPTION
## Summary
- remove RegionEvents dependency
- track player regions directly via WorldGuard
- start polling task in `RegionListener`
- clean up imports and plugin.yml
- update README to reflect new behaviour

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687b9483acf8832cb4eab58c31583067